### PR TITLE
HADOOP-17229. No updation of bytes received counter value after respo…

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -177,8 +177,12 @@ public class AbfsRestOperation {
 
       httpOperation.processResponse(buffer, bufferOffset, bufferLength);
       incrementCounter(AbfsStatistic.GET_RESPONSES, 1);
-      incrementCounter(AbfsStatistic.BYTES_RECEIVED,
-          httpOperation.getBytesReceived());
+      //Only increment bytesReceived counter when the status code is 2XX.
+      if (httpOperation.getStatusCode() >= HttpURLConnection.HTTP_OK
+          && httpOperation.getStatusCode() <= HttpURLConnection.HTTP_PARTIAL) {
+        incrementCounter(AbfsStatistic.BYTES_RECEIVED,
+            httpOperation.getBytesReceived());
+      }
     } catch (IOException ex) {
       if (ex instanceof UnknownHostException) {
         LOG.warn(String.format("Unknown host name: %s. Retrying to resolve the host name...", httpOperation.getUrl().getHost()));


### PR DESCRIPTION
…nse failure occurs in ABFS (#2264)

Contributed by Mehakmeet Singh

(cherry picked from commit 0d855159f0956af3070a1a173c8a6cb2c71a1ea3)

<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
It is a clean cherry pick of commit 0d855159f0956af3070a1a173c8a6cb2c71a1ea3
I am trying to backport fix for https://issues.apache.org/jira/browse/HADOOP-17215 (https://github.com/apache/hadoop/pull/2246). In order to cleanly cherry pick this commit from branch-3.3 to branch-2.10 , I need to cherry pick several other commits before I pick this one. The commit being picked in this PR is one of those several commits.

### How was this patch tested?
Ran mvn test -pl hadoop-tools/hadoop-azure
No new unit tests fail.

Ran all integration abfs tests using mvn -T 1C -Dparallel-tests=abfs clean verify with my storage account arjundev.dfs.core.windows.net
Storage account's Primary location: East US, Secondary location: West US

No tests failed. There are 17 errors; these were negative test cases where error was expected.

`
[INFO] Results:
[INFO] 
[INFO] Tests run: 57, Failures: 0, Errors: 0, Skipped: 0

[INFO] Results:
[INFO] 
[WARNING] Tests run: 151, Failures: 0, Errors: 0, Skipped: 24

[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:67->getTestUserFs:79 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:67->getTestUserFs:79 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:67->getTestUserFs:79 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:67->getTestUserFs:79 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:67->getTestUserFs:79 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:67->getTestUserFs:79 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:67->getTestUserFs:79 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:67->getTestUserFs:79 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:67->getTestUserFs:79 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:67->getTestUserFs:79 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCheckAccess.<init>:67->getTestUserFs:79 » IllegalArgument
[ERROR]   ITestAzureBlobFileSystemCreate.testFilterFSWriteAfterClose:182 » IO java.io.Fi...
[ERROR]   ITestAzureBlobFileSystemE2E.testFlushWithFileNotFoundException:224 » IO java.i...
[ERROR]   ITestAzureBlobFileSystemE2E.testWriteWithFileNotFoundException:204 » IO java.i...
[ERROR]   ITestAzureBlobFileSystemRenameWhenDelete>ITestAzureBlobFileSystemDelete.testDeleteDirectory:103 » AbfsRestOperation
[ERROR]   ITestAzureBlobFileSystemRenameWhenDelete>ITestAzureBlobFileSystemDelete.testDeleteFirstLevelDirectory:140 » AbfsRestOperation
[ERROR]   ITestAzureBlobFileSystemRenameWhenDelete>ITestAzureBlobFileSystemDelete.testDeleteRoot:65 » IO
[INFO] 
[ERROR] Tests run: 429, Failures: 0, Errors: 17, Skipped: 242
`

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [x] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

